### PR TITLE
url_launcherの設定と表示できるスキーマの制限

### DIFF
--- a/application/android/app/src/main/AndroidManifest.xml
+++ b/application/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,33 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<!-- The INTERNET permission is required for development. Specifically,
+       flutter needs it to communicate with the running application
+       to allow setting breakpoints, to provide hot reload, etc.
+  -->
+  <uses-permission android:name="android.permission.INTERNET"/>
+
+  <!--#docregion android-queries-->
+  <!-- Provide required visibility configuration for API level 30 and above -->
+  <queries>
+    <!-- If your app checks for SMS support -->
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="sms" />
+    </intent>
+    <!-- If your app checks for call support -->
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="tel" />
+    </intent>
+    <!--#enddocregion android-queries-->
+    <!-- The "https" scheme is only required for integration tests of this package.
+         It shouldn't be needed in most actual apps, or show up in the README! -->
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="https" />
+    </intent>
+    <!--#docregion android-queries-->
+  </queries>
+  <!--#enddocregion android-queries-->
     <application
         android:label="application"
         android:name="${applicationName}"

--- a/application/ios/Runner/Info.plist
+++ b/application/ios/Runner/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+	  <string>sms</string>
+	  <string>tel</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/application/lib/features/repository_detail/controller.dart
+++ b/application/lib/features/repository_detail/controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -14,6 +15,21 @@ class RepositoryDetailController {
     if (href == null) {
       return;
     }
-    await launchUrl(Uri.parse(href));
+    final url = Uri.parse(href);
+    const supportedSchemes = [
+      'https',
+      "tel",
+      "sms",
+    ];
+    if (kDebugMode) {
+      print('onPressedReadMeLink: $url');
+    }
+    if (!supportedSchemes.contains(url.scheme)) {
+      return;
+    }
+    if (await canLaunchUrl(url)) {
+      return;
+    }
+    await launchUrl(url);
   }
 }

--- a/application/lib/features/repository_detail/controller.dart
+++ b/application/lib/features/repository_detail/controller.dart
@@ -1,3 +1,4 @@
+import 'package:application/models/repository_readme.model.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -6,29 +7,39 @@ part 'controller.g.dart';
 
 @riverpod
 RepositoryDetailController repositoryDetailController(
-        AutoDisposeProviderRef ref) =>
-    RepositoryDetailController();
+        AutoDisposeProviderRef ref, RepositoryReadMe readMe) =>
+    RepositoryDetailController(
+      readMe: readMe,
+    );
 
 class RepositoryDetailController {
+  final RepositoryReadMe readMe;
+
+  RepositoryDetailController({required this.readMe});
+
   Future<void> onPressedReadMeLink(
       {required String text, required String? href}) async {
     if (href == null) {
       return;
     }
-    final url = Uri.parse(href);
     const supportedSchemes = [
       'https',
       "tel",
       "sms",
     ];
+    final Uri url;
+    if (supportedSchemes.contains(href.split(":").first)) {
+      url = Uri.parse(href);
+    } else {
+      // #タグがある場合はREADME.mdのコンテンツを開く
+      if (href.startsWith("#")) {
+        url = Uri.parse(readMe.contentUrl + href);
+      } else {
+        return;
+      }
+    }
     if (kDebugMode) {
       print('onPressedReadMeLink: $url');
-    }
-    if (!supportedSchemes.contains(url.scheme)) {
-      return;
-    }
-    if (await canLaunchUrl(url)) {
-      return;
     }
     await launchUrl(url);
   }

--- a/application/lib/features/repository_detail/controller.g.dart
+++ b/application/lib/features/repository_detail/controller.g.dart
@@ -7,22 +7,160 @@ part of 'controller.dart';
 // **************************************************************************
 
 String _$repositoryDetailControllerHash() =>
-    r'78c3167267d485803e443fec8913ed78a9182de5';
+    r'3ceecd8a14b32a072f9e63db7280ae5e7ce3d269';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
 
 /// See also [repositoryDetailController].
 @ProviderFor(repositoryDetailController)
-final repositoryDetailControllerProvider =
-    AutoDisposeProvider<RepositoryDetailController>.internal(
-  repositoryDetailController,
-  name: r'repositoryDetailControllerProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$repositoryDetailControllerHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+const repositoryDetailControllerProvider = RepositoryDetailControllerFamily();
 
-typedef RepositoryDetailControllerRef
-    = AutoDisposeProviderRef<RepositoryDetailController>;
+/// See also [repositoryDetailController].
+class RepositoryDetailControllerFamily
+    extends Family<RepositoryDetailController> {
+  /// See also [repositoryDetailController].
+  const RepositoryDetailControllerFamily();
+
+  /// See also [repositoryDetailController].
+  RepositoryDetailControllerProvider call(
+    RepositoryReadMe readMe,
+  ) {
+    return RepositoryDetailControllerProvider(
+      readMe,
+    );
+  }
+
+  @override
+  RepositoryDetailControllerProvider getProviderOverride(
+    covariant RepositoryDetailControllerProvider provider,
+  ) {
+    return call(
+      provider.readMe,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'repositoryDetailControllerProvider';
+}
+
+/// See also [repositoryDetailController].
+class RepositoryDetailControllerProvider
+    extends AutoDisposeProvider<RepositoryDetailController> {
+  /// See also [repositoryDetailController].
+  RepositoryDetailControllerProvider(
+    RepositoryReadMe readMe,
+  ) : this._internal(
+          (ref) => repositoryDetailController(
+            ref as RepositoryDetailControllerRef,
+            readMe,
+          ),
+          from: repositoryDetailControllerProvider,
+          name: r'repositoryDetailControllerProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$repositoryDetailControllerHash,
+          dependencies: RepositoryDetailControllerFamily._dependencies,
+          allTransitiveDependencies:
+              RepositoryDetailControllerFamily._allTransitiveDependencies,
+          readMe: readMe,
+        );
+
+  RepositoryDetailControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.readMe,
+  }) : super.internal();
+
+  final RepositoryReadMe readMe;
+
+  @override
+  Override overrideWith(
+    RepositoryDetailController Function(RepositoryDetailControllerRef provider)
+        create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: RepositoryDetailControllerProvider._internal(
+        (ref) => create(ref as RepositoryDetailControllerRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        readMe: readMe,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeProviderElement<RepositoryDetailController> createElement() {
+    return _RepositoryDetailControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is RepositoryDetailControllerProvider &&
+        other.readMe == readMe;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, readMe.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin RepositoryDetailControllerRef
+    on AutoDisposeProviderRef<RepositoryDetailController> {
+  /// The parameter `readMe` of this provider.
+  RepositoryReadMe get readMe;
+}
+
+class _RepositoryDetailControllerProviderElement
+    extends AutoDisposeProviderElement<RepositoryDetailController>
+    with RepositoryDetailControllerRef {
+  _RepositoryDetailControllerProviderElement(super.provider);
+
+  @override
+  RepositoryReadMe get readMe =>
+      (origin as RepositoryDetailControllerProvider).readMe;
+}
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/application/lib/features/repository_detail/page.dart
+++ b/application/lib/features/repository_detail/page.dart
@@ -216,7 +216,8 @@ class RepositoryDetailPage extends FeaturePage<RepositoryDetailState> {
                       extensionSet: ExtensionSet.gitHubFlavored,
                       onTapLink: (text, href, title) async {
                         await ref
-                            .read(repositoryDetailControllerProvider)
+                            .read(repositoryDetailControllerProvider(
+                                state.readMe!))
                             .onPressedReadMeLink(
                               text: text,
                               href: href,

--- a/application/lib/models/repository_readme.model.dart
+++ b/application/lib/models/repository_readme.model.dart
@@ -14,3 +14,7 @@ class RepositoryReadMe with _$RepositoryReadMe {
   factory RepositoryReadMe.fromJson(Map<String, dynamic> json) =>
       _$RepositoryReadMeFromJson(json);
 }
+
+extension RepositoryReadMeX on RepositoryReadMe {
+  String get contentUrl => "https://github.com/$owner/$name?tab=readme-ov-file";
+}

--- a/application/lib/network/github_repository_readme.request.dart
+++ b/application/lib/network/github_repository_readme.request.dart
@@ -18,7 +18,7 @@ class GetGitHubRepositoryReadMeRequest with NetworkRequest {
   @override
   Map<String, String> get headers => {
         ...super.defaultHeaders,
-        'Accept': 'application/vnd.github.raw+json',
+        'Accept': 'application/json',
       };
 
   @override

--- a/application/lib/services/repository.service.dart
+++ b/application/lib/services/repository.service.dart
@@ -77,7 +77,9 @@ class RepositoryService {
       );
       final response = await _apiClient.send(request);
       if (response.statusCode == 200) {
-        final content = response.body;
+        final json = jsonDecode(response.body);
+        final base64Content = (json['content'] as String).replaceAll("\n", "");
+        final content = utf8.decode(base64.decode(base64Content));
         final repositoryReadMe = RepositoryReadMe(
           content: content,
           owner: owner,

--- a/application/scripts/run-android.sh
+++ b/application/scripts/run-android.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-targetDeviceName="sdk gphone arm64"
-fvm flutter run -d "$targetDeviceName" --dart-define-from-file=config.json

--- a/application/scripts/run-ios.sh
+++ b/application/scripts/run-ios.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-targetDeviceName="iPhone 15 Pro"
-fvm flutter emulators --launch ios
-fvm flutter run -d "$targetDeviceName" --dart-define-from-file=config.json

--- a/application/test/features/repository_detail/page_test.dart
+++ b/application/test/features/repository_detail/page_test.dart
@@ -79,6 +79,11 @@ void main() {
         const name = "name";
         const expectedUrl = "https://example.com";
         final expectedRepository = RepositoryTestHelper().make(1)[0];
+        final readMe = RepositoryReadMe(
+          owner: owner,
+          name: name,
+          content: "# ReadMe\n\nYou can tap [here]($expectedUrl).",
+        );
         provideDummy<Repository>(expectedRepository);
         when(mockRepositoryService.getRepository(
           owner: anyNamed("owner"),
@@ -92,11 +97,7 @@ void main() {
             name: anyNamed("name"),
           ),
         ).thenAnswer((_) async {
-          return RepositoryReadMe(
-            owner: owner,
-            name: name,
-            content: "# ReadMe\n\nYou can tap [here]($expectedUrl).",
-          );
+          return readMe;
         });
         when(mockRepositoryDetailController.onPressedReadMeLink(
           text: anyNamed("text"),
@@ -108,7 +109,7 @@ void main() {
             overrides: [
               repositoryServiceProvider
                   .overrideWith((ref) => mockRepositoryService),
-              repositoryDetailControllerProvider
+              repositoryDetailControllerProvider(readMe)
                   .overrideWith((ref) => mockRepositoryDetailController),
             ],
             child: MaterialApp(

--- a/application/test/features/repository_detail/page_test.mocks.dart
+++ b/application/test/features/repository_detail/page_test.mocks.dart
@@ -140,6 +140,19 @@ class MockRepositoryService extends _i1.Mock implements _i3.RepositoryService {
 class MockRepositoryDetailController extends _i1.Mock
     implements _i7.RepositoryDetailController {
   @override
+  _i2.RepositoryReadMe get readMe => (super.noSuchMethod(
+        Invocation.getter(#readMe),
+        returnValue: _FakeRepositoryReadMe_0(
+          this,
+          Invocation.getter(#readMe),
+        ),
+        returnValueForMissingStub: _FakeRepositoryReadMe_0(
+          this,
+          Invocation.getter(#readMe),
+        ),
+      ) as _i2.RepositoryReadMe);
+
+  @override
   _i4.Future<void> onPressedReadMeLink({
     required String? text,
     required String? href,

--- a/application/test/services/repository_service_test.dart
+++ b/application/test/services/repository_service_test.dart
@@ -99,7 +99,9 @@ void main() {
         const name = "name";
         when(apiClient.send(any)).thenAnswer(
           (_) async => Response(
-            readMeContent,
+            jsonEncode({
+              "content": base64Encode(utf8.encode(readMeContent)),
+            }),
             200,
           ),
         );


### PR DESCRIPTION
- 表示できるURLのスキーマを「https, tel, sms」に制限しました
    - [url_launcherの設定](https://pub.dev/packages/url_launcher#configuration) の対応
  - マークダウン内にある相対パスやファイル内部のタグに遷移する処理を対応するにはREADME.mdのファイルパスが必要